### PR TITLE
Make european countries sphere-annex uncivs only in Africa

### DIFF
--- a/CoE/events/Scramble for Africa.txt
+++ b/CoE/events/Scramble for Africa.txt
@@ -249,6 +249,7 @@ country_event = {
 	picture = "scramble_for_africa"
 	
 	trigger = {
+		capital_scope = { continent = africa }
 		exists = yes
 		has_global_flag = berlin_conference
 		NOT = { is_culture_group = east_asian }


### PR DESCRIPTION
So, there has been a problem regarding rather unrealistic annexations of all uncivilized countries that are in a european sphere, for example the UK sphere-annexing Persia. Or all the Indian princely-states. This is through an event within the file Scramble for _Africa_.txt

This small patch changes that to only countries whose capital is in Africa.